### PR TITLE
Convert the Tabs component

### DIFF
--- a/src/ThemeablePolarisReact/styles.scss
+++ b/src/ThemeablePolarisReact/styles.scss
@@ -9,5 +9,7 @@ $themes: (
     tab-selected-title-border: color('indigo'),
 
     disclosure-activator-icon: color('ink', 'lighter'),
+
+    background: blue,
   ),
 );

--- a/src/ThemeablePolarisReact/themes.scss
+++ b/src/ThemeablePolarisReact/themes.scss
@@ -7,5 +7,7 @@ $themes: (
     tab-focus-title-border: color('indigo', 'light'),
     tab-visited: color('ink', 'lighter'),
     tab-selected-title-border: color('indigo'),
+
+    disclosure-activator-icon: color('ink', 'lighter'),
   ),
 );

--- a/src/ThemeablePolarisReact/themes.scss
+++ b/src/ThemeablePolarisReact/themes.scss
@@ -1,0 +1,11 @@
+$focus-state-box-shadow-color: rgba(92, 106, 196, 0.8);
+
+$themes: (
+  default: (
+    tab-title-hover: color('sky'),
+    tab-focus-box-shadow: $focus-state-box-shadow-color,
+    tab-focus-title-border: color('indigo', 'light'),
+    tab-visited: color('ink', 'lighter'),
+    tab-selected-title-border: color('indigo'),
+  ),
+);

--- a/src/components/Tabs/Tabs.scss
+++ b/src/components/Tabs/Tabs.scss
@@ -3,7 +3,6 @@
 $item-min-height: rem(16px);
 $item-min-width: rem(50px);
 $item-vertical-padding: $item-min-height / 2;
-$focus-state-box-shadow-color: rgba(92, 106, 196, 0.8);
 
 .Tabs {
   display: flex;
@@ -43,8 +42,6 @@ $focus-state-box-shadow-color: rgba(92, 106, 196, 0.8);
 @mixin Tab {
   @each $themeType, $theme in $themes {
     &-#{$themeType} {
-      // background: map-get($theme, foo);
-
       @include unstyled-link;
       @include unstyled-button;
       @include text-style-body;
@@ -177,17 +174,25 @@ $focus-state-box-shadow-color: rgba(92, 106, 196, 0.8);
   display: flex;
 }
 
+@mixin DisclosureActivator {
+  @each $themeType, $theme in $themes {
+    &-#{$themeType} {
+      @include recolor-icon(map-get($theme, disclosure-activator-icon));
+      position: relative;
+      justify-content: center;
+      height: 100%;
+      padding: 0 spacing();
+      background-color: transparent;
+      cursor: pointer;
+      border: none;
+      outline: none;
+      text-align: center;
+    }
+  }
+}
+
 .DisclosureActivator {
-  @include recolor-icon(color('ink', 'lighter'));
-  position: relative;
-  justify-content: center;
-  height: 100%;
-  padding: 0 spacing();
-  background-color: transparent;
-  cursor: pointer;
-  border: none;
-  outline: none;
-  text-align: center;
+  @include DisclosureActivator;
 }
 
 .TabMeasurer {

--- a/src/components/Tabs/Tabs.scss
+++ b/src/components/Tabs/Tabs.scss
@@ -1,4 +1,16 @@
+@import 'src/ThemeablePolarisReact/styles';
 @import 'src/ThemeablePolarisReact/themes';
+
+@function findcolor($theme, $styleName) {
+  @if map-has-key($theme, $styleName) {
+    @return map-get($theme, $styleName);
+
+  } @else {
+    $scoped: map-get($themes, 'default');
+
+    @return map-get($scoped, $styleName);
+  }
+}
 
 $item-min-height: rem(16px);
 $item-min-width: rem(50px);
@@ -58,6 +70,7 @@ $item-vertical-padding: $item-min-height / 2;
       white-space: nowrap;
       text-decoration: none;
       cursor: pointer;
+      background: findcolor($theme, background);
 
       &:hover {
         .Title {

--- a/src/components/Tabs/Tabs.scss
+++ b/src/components/Tabs/Tabs.scss
@@ -1,3 +1,5 @@
+@import 'src/ThemeablePolarisReact/themes';
+
 $item-min-height: rem(16px);
 $item-min-width: rem(50px);
 $item-vertical-padding: $item-min-height / 2;
@@ -38,52 +40,68 @@ $focus-state-box-shadow-color: rgba(92, 106, 196, 0.8);
   padding: 0;
 }
 
-.Tab {
-  @include unstyled-link;
-  @include unstyled-button;
-  @include text-style-body;
-  @include text-emphasis-subdued;
-  position: relative;
-  justify-content: center;
-  width: 100%;
-  min-width: 100%; // IE11 fix for overflowing flex items from parent container
-  margin-top: 1px;
-  margin-bottom: -1px;
-  padding: 0 spacing();
-  outline: none;
-  text-align: center;
-  white-space: nowrap;
-  text-decoration: none;
-  cursor: pointer;
+@mixin Tab {
+  @each $themeType, $theme in $themes {
+    &-#{$themeType} {
+      // background: map-get($theme, foo);
 
-  &:hover {
-    .Title {
-      @include text-emphasis-normal;
+      @include unstyled-link;
+      @include unstyled-button;
+      @include text-style-body;
+      @include text-emphasis-subdued;
+      position: relative;
+      justify-content: center;
+      width: 100%;
+      min-width: 100%; // IE11 fix for overflowing flex items from parent container
+      margin-top: 1px;
+      margin-bottom: -1px;
+      padding: 0 spacing();
+      outline: none;
+      text-align: center;
+      white-space: nowrap;
       text-decoration: none;
-      border-bottom: border-width(thicker) solid color('sky');
+      cursor: pointer;
+
+      &:hover {
+        .Title {
+          @include text-emphasis-normal;
+          text-decoration: none;
+          border-bottom: border-width(thicker)
+            solid
+            map-get($theme, tab-title-hover);
+        }
+      }
+
+      &:focus {
+        box-shadow: inset 0 0 2px 0 map-get($theme, tab-focus-box-shadow),
+          0 0 2px 0 map-get($theme, tab-focus-box-shadow);
+
+        .Title {
+          @include text-emphasis-normal;
+          border-bottom: border-width(thicker)
+            solid
+            map-get($theme, tab-focus-title-border);
+        }
+      }
+
+      &:visited {
+        color: map-get($theme, tab-visited);
+      }
+
+      &.Tab-selected {
+        // stylelint-disable-next-line selector-max-class
+        .Title {
+          border-bottom: border-width(thicker)
+            solid
+            map-get($theme, tab-selected-title-border);
+        }
+      }
     }
   }
+}
 
-  &:focus {
-    box-shadow: inset 0 0 2px 0 $focus-state-box-shadow-color,
-      0 0 2px 0 $focus-state-box-shadow-color;
-
-    .Title {
-      @include text-emphasis-normal;
-      border-bottom: border-width(thicker) solid color('indigo', 'light');
-    }
-  }
-
-  &:visited {
-    color: color('ink', 'lighter');
-  }
-
-  &.Tab-selected {
-    // stylelint-disable-next-line selector-max-class
-    .Title {
-      border-bottom: border-width(thicker) solid color('indigo');
-    }
-  }
+.Tab {
+  @include Tab;
 }
 
 .Tab-selected {

--- a/src/components/Tabs/Tabs.tsx
+++ b/src/components/Tabs/Tabs.tsx
@@ -22,6 +22,8 @@ export interface Props {
   tabs: TabDescriptor[];
   /** Fit tabs to container */
   fitted?: boolean;
+  /** Name of theme */
+  theme?: string;
   /** Callback when tab is selected */
   onSelect?(selectedTabIndex: number): void;
 }
@@ -70,7 +72,7 @@ export default class Tabs extends React.PureComponent<Props, State> {
   }
 
   render() {
-    const {tabs, selected, fitted, children} = this.props;
+    const {tabs, selected, fitted, theme = 'default', children} = this.props;
     const {tabToFocus, visibleTabs, hiddenTabs, showDisclosure} = this.state;
     const disclosureTabs = hiddenTabs.map((tabIndex) => tabs[tabIndex]);
 
@@ -144,6 +146,7 @@ export default class Tabs extends React.PureComponent<Props, State> {
           tabs={tabs}
           siblingTabHasFocus={tabToFocus > -1}
           handleMeasurement={this.handleMeasurement}
+          theme={theme}
         />
         {panelMarkup}
       </div>
@@ -181,7 +184,7 @@ export default class Tabs extends React.PureComponent<Props, State> {
 
   @autobind
   private renderTabMarkup(tab: TabDescriptor, index: number) {
-    const {selected} = this.props;
+    const {selected, theme = 'default'} = this.props;
     const {tabToFocus} = this.state;
 
     return (
@@ -195,6 +198,7 @@ export default class Tabs extends React.PureComponent<Props, State> {
         panelID={tab.panelID || `${tab.id}-panel`}
         accessibilityLabel={tab.accessibilityLabel}
         url={tab.url}
+        theme={theme}
       >
         {tab.content}
       </Tab>
@@ -203,13 +207,13 @@ export default class Tabs extends React.PureComponent<Props, State> {
 
   @autobind
   private handleFocus(event: React.FocusEvent<HTMLUListElement>) {
-    const {selected, tabs} = this.props;
+    const {selected, tabs, theme = 'default'} = this.props;
 
     // If we are explicitly focusing one of the non-selected tabs, use it
     // move the focus to it
     const target = event.target as HTMLElement;
     if (
-      target.classList.contains(styles.Tab) ||
+      target.classList.contains(styles[`Tab-${theme}`]) ||
       target.classList.contains(styles.Item)
     ) {
       let tabToFocus = -1;
@@ -241,7 +245,7 @@ export default class Tabs extends React.PureComponent<Props, State> {
 
     const relatedTarget = event.relatedTarget as HTMLElement;
     if (
-      !relatedTarget.classList.contains(styles.Tab) &&
+      !relatedTarget.classList.contains(styles[`Tab-${theme}`]) &&
       !relatedTarget.classList.contains(styles.Item) &&
       !relatedTarget.classList.contains(styles.DisclosureActivator)
     ) {
@@ -251,6 +255,8 @@ export default class Tabs extends React.PureComponent<Props, State> {
 
   @autobind
   private handleBlur(event: React.FocusEvent<HTMLUListElement>) {
+    const {theme = 'default'} = this.props;
+
     // If we blur and the target is not another tab, forget the focus position
     if (event.relatedTarget == null) {
       this.setState({tabToFocus: -1});
@@ -261,7 +267,7 @@ export default class Tabs extends React.PureComponent<Props, State> {
 
     // If we are going to anywhere other than another tab, lose the last focused tab
     if (
-      !target.classList.contains(styles.Tab) &&
+      !target.classList.contains(styles[`Tab-${theme}`]) &&
       !target.classList.contains(styles.Item)
     ) {
       this.setState({tabToFocus: -1});

--- a/src/components/Tabs/components/Tab/Tab.tsx
+++ b/src/components/Tabs/components/Tab/Tab.tsx
@@ -19,6 +19,7 @@ export interface Props {
   url?: string;
   measuring?: boolean;
   accessibilityLabel?: string;
+  theme: string;
   onClick?(id: string): void;
 }
 
@@ -77,12 +78,13 @@ export class Tab extends React.PureComponent<CombinedProps, never> {
       panelID,
       measuring,
       accessibilityLabel,
+      theme,
     } = this.props;
 
     const handleClick = onClick && onClick.bind(null, id);
 
     const className = classNames(
-      styles.Tab,
+      styles[`Tab-${theme}`],
       selected && styles['Tab-selected'],
     );
 

--- a/src/components/Tabs/components/TabMeasurer/TabMeasurer.tsx
+++ b/src/components/Tabs/components/TabMeasurer/TabMeasurer.tsx
@@ -22,6 +22,7 @@ export interface Props {
   activator: React.ReactElement<{}>;
   selected: number;
   tabs: TabDescriptor[];
+  theme: string;
   handleMeasurement(measurements: TabMeasurements): void;
 }
 
@@ -51,6 +52,7 @@ export default class TabMeasurer extends React.PureComponent<Props, never> {
       activator,
       tabToFocus,
       siblingTabHasFocus,
+      theme,
     } = this.props;
 
     const tabsMarkup = tabs.map((tab, index) => {
@@ -64,6 +66,7 @@ export default class TabMeasurer extends React.PureComponent<Props, never> {
           selected={index === selected}
           onClick={noop}
           url={tab.url}
+          theme={theme}
         >
           {tab.content}
         </Tab>


### PR DESCRIPTION
## What does this accomplish?

This converts the `Tabs` component to support theming.

## How is this accomplished?

The `Tabs` component has an optional prop `theme` which it uses to call styles and passes to other components. Components such as `Tab` and `TabMeasurer` have `theme` as a required prop since the parent component should always be passing some value, even if it is only rendering the default look.

User styles will live in `src/ThemeablePolarisReact/themes.scss`.